### PR TITLE
Tried using \freeform in Chicken Adobo recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ be located in '~/Dropbox/'.
 To create `cookbook.pdf` simply run `make cookbook`.
 
 [![Stories in Ready](https://badge.waffle.io/syounkin/cookbook.png?label=ready&title=Ready)](https://waffle.io/syounkin/cookbook)
+

--- a/recipes/chicken-adobo.tex
+++ b/recipes/chicken-adobo.tex
@@ -10,16 +10,20 @@
 \ing[1\fr12]{tsp}{freshly ground black pepper}
 \ing[3-4]{lbs}{chicken thighs}
 
-Combine all of the marinade ingredients in a large, nonreactive bowl or resealable plastic freezer bag. Add the chicken and turn to coat. Refrigerate overnight or for at least 2 hours.
-\newline
+Combine all of the marinade ingredients in a large, nonreactive bowl
+or resealable plastic freezer bag. Add the chicken and turn to
+coat. Refrigerate overnight or for at least 2 hours.
 
-Place chicken and marinade in a large lidded pot or Dutch oven over high heat and bring to a boil. Immediately reduce heat to a simmer and cook, stirring occasionally, until the chicken is cooked through and tender, around 30 minutes.
-\newline
-
-Heat broiler. Transfer chicken pieces to a large bowl, raise heat under the pot to medium-high, and reduce the sauce until it achieves almost the consistency of cream, about 10 minutes. Remove bay leaves and chilies.
-\newline
-
-Place chicken pieces on a roasting pan and place under broiler for 5 to 7 minutes, until they begin to caramelize. Remove, turn chicken, baste with sauce and repeat, 3 to 5 minutes more. Return chicken to sauce and cook for a few minutes more, then place on a platter and drizzle heavily with sauce.
-\newline
-
+\freeform Place chicken and marinade in a large lidded pot or Dutch
+oven over high heat and bring to a boil. Immediately reduce heat to a
+simmer and cook, stirring occasionally, until the chicken is cooked
+through and tender, around 30 minutes.  Heat broiler. Transfer chicken
+pieces to a large bowl, raise heat under the pot to medium-high, and
+reduce the sauce until it achieves almost the consistency of cream,
+about 10 minutes. Remove bay leaves and chilies.  Place chicken pieces
+on a roasting pan and place under broiler for 5 to 7 minutes, until
+they begin to caramelize. Remove, turn chicken, baste with sauce and
+repeat, 3 to 5 minutes more. Return chicken to sauce and cook for a
+few minutes more, then place on a platter and drizzle heavily with
+sauce.
 \end{recipe}


### PR DESCRIPTION
Recipe steps that have no ingredients can make the layout look bad.  To solve I tried using `\freeform` for much of the recipe.  It would probably be better if we could break that up into steps.  This work connects to #15.